### PR TITLE
Added mininal assume-role support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ If installed locally, the path will be `node_modules/.bin/tail-stack-events`.
  --key key         API key to use connect to AWS
  --secret secret   API secret to use to connect to AWS
  --region region   The AWS region the stack is in (defaults to us-east-1)
+ --assume-role     The AWS IAM role ARN to assume
  
  Credentials:
    By default, this script will use the default credentials you have
@@ -45,6 +46,8 @@ If installed locally, the path will be `node_modules/.bin/tail-stack-events`.
    wish to use a different profile, specify the name in the --profile
    option. If you with to specify the key/secret manually, use the
    --key and --secret options.
+   If named profile cannot be constructed, program will still try to use 
+   default credentials.  
  
  Examples:
  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,116 @@
+{
+	"name": "tail-stack-events",
+	"version": "1.2.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"aws-sdk": {
+			"version": "2.401.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.401.0.tgz",
+			"integrity": "sha512-mOI4gzKoP/g8Q0ToAaqTh7TijGG9PvGVVUkKmurXqBKy7GTPmy4JizfVkTrM+iBg7RAsx5H2lBxBFpdEFBa5fg==",
+			"dev": true,
+			"requires": {
+				"buffer": "4.9.1",
+				"events": "1.1.1",
+				"ieee754": "1.1.8",
+				"jmespath": "0.15.0",
+				"querystring": "0.2.0",
+				"sax": "1.2.1",
+				"url": "0.10.3",
+				"uuid": "3.3.2",
+				"xml2js": "0.4.19"
+			}
+		},
+		"base64-js": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+			"dev": true
+		},
+		"buffer": {
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+			"dev": true,
+			"requires": {
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4",
+				"isarray": "^1.0.0"
+			}
+		},
+		"events": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+			"dev": true
+		},
+		"ieee754": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"jmespath": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+			"dev": true
+		},
+		"punycode": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+			"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+			"dev": true
+		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+			"dev": true
+		},
+		"sax": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+			"integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+			"dev": true
+		},
+		"url": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+			"integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+			"dev": true,
+			"requires": {
+				"punycode": "1.3.2",
+				"querystring": "0.2.0"
+			}
+		},
+		"uuid": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"dev": true
+		},
+		"xml2js": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+			"dev": true,
+			"requires": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~9.0.1"
+			}
+		},
+		"xmlbuilder": {
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+			"dev": true
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -6,13 +6,11 @@
 		"type": "git",
 		"url": "https://github.com/tmont/tail-stack-events.git"
 	},
-
 	"bin": "tail-stack-events.js",
-
-	"peerDependencies": {
+	"dependencies": {
 		"aws-sdk": "2.x"
 	},
 	"devDependencies": {
-		"aws-sdk": "2.x"
+		"aws-sdk": "^2.401.0"
 	}
 }

--- a/tail-stack-events.js
+++ b/tail-stack-events.js
@@ -61,7 +61,7 @@ Usage: ${path.basename(__filename)} [--port port] [--procfile file] [...processe
 --key key         API key to use connect to AWS
 --secret secret   API secret to use to connect to AWS
 --region region   The AWS region the stack is in (defaults to us-east-1)
---assume-role <ARN>   The AWS IAM role ARN to assume, 
+--assume-role <ARN>   The AWS IAM role ARN to assume
 `);
 	console.log(`Credentials:
   By default, this script will use the default credentials you have


### PR DESCRIPTION
It may be a bit clumsy, in theory AWS SDK should support picking `credential_source` from profile file out-of the box, but the support hasn't been implemented yet (tracking: https://github.com/aws/aws-sdk-js/issues/1916)

So, I assumed, that even if try to pick up a profile via `--profile` and it failed to initialize, it still good to use SDK defaults https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CredentialProviderChain.html#defaultProviders-property

Also, added `package-lock.json`, due to NPM recommendations. https://docs.npmjs.com/files/package-locks#using-locked-packages 